### PR TITLE
Tweaks for interoperating with DIDComm resolver plugin

### DIFF
--- a/aries_cloudagent/protocols/resolve_did/v0_9/message_types.py
+++ b/aries_cloudagent/protocols/resolve_did/v0_9/message_types.py
@@ -8,7 +8,7 @@ SPEC_URI = (
     "0124-did-resolution-protocol"
 )
 
-PROTOCOL_URI = "https://didcomm.org/did_resolution/0.1"
+PROTOCOL_URI = "https://didcomm.org/did_resolution/0.9"
 
 RESOLVE = f"{PROTOCOL_URI}/resolve"
 RESOLVE_RESULT = f"{PROTOCOL_URI}/resolve_result"

--- a/aries_cloudagent/protocols/resolve_did/v0_9/messages/resolve_did_result.py
+++ b/aries_cloudagent/protocols/resolve_did/v0_9/messages/resolve_did_result.py
@@ -33,7 +33,7 @@ class ResolveDidResult(AgentMessage):
         self,
         *,
         sent_time: Union[str, datetime] = None,
-        did_document: str = None,
+        did_document: dict = None,
         localization: str = None,
         **kwargs,
     ):
@@ -53,8 +53,6 @@ class ResolveDidResult(AgentMessage):
         if localization:
             self._decorators["l10n"] = localization
         self.sent_time = datetime_to_str(sent_time)
-        if not isinstance(did_document, str):
-            did_document = json.dumps(did_document)
         self.did_document = did_document
 
 
@@ -72,5 +70,5 @@ class ResolveDidResultSchema(AgentMessageSchema):
         **INDY_ISO8601_DATETIME,
     )
     example = '{"@context": "https://w3id.org/did/v0.11", "id": "did:sov:xyz",}'
-    did_document = fields.Str(required=True, description="DID",
+    did_document = fields.Dict(required=True, description="DID Document",
                               example=example)


### PR DESCRIPTION
With these tweaks, we are able to achieve happy path DID resolution over DIDComm! While small, I recognize that these tweaks may have implications on the functionality of your demos.

In order to get the unhappy path to work, we rely on the sending of an adopted problem report message, i.e. `https://didcomm.org/did_resolution/0.9/problem-report` with the `~thread` decorator present and `thid` set to the message id of the `resolve` message. This enables the requester to know when a document was not found by the resolver. Otherwise, we just have to timeout and assume it didn't work. We can follow up this PR with a quick port of our problem report message and modifications to the resolve handler to make sure it's sent when appropriate.